### PR TITLE
Update registry to include buffer map values

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,6 +67,10 @@
 			<li>Each entry should include a link that references a public available
 			specification (PAS) that defines the associated interface type.</li>
 			<li>Each entry must include contact information of the requestor.</li>
+                        <li>Each entry must include an <dfn data-cite=
+		'PERFORMANCE-TIMELINE-2#dom-performancetimeline-availableFromTimeline'><code>availableFromTimeline</code></dfn> boolean.
+                        <li>Each entry must include a <dfn data-cite=
+		'PERFORMANCE-TIMELINE-2#dom-performancetimeline-maxBufferSize'><code>maxBufferSize</code></dfn> indication.
 		</ul>
 		<p>An update to this registry is an addition, change or deletion of an
 		identifier. Any person can request an update to this registry by pull
@@ -87,6 +91,8 @@
 				<tr>
 					<th><code>entryType</code> Identifier</th>
 					<th>Interface Type(s)</th>
+                                        <th>Available From Timeline</th>
+                                        <th>Max Buffer Size</th>
 					<th>Public Specification(s)</th>
 					<th>Requestor Contact</th>
 				</tr>
@@ -97,6 +103,8 @@
 					<td>
 						<a data-cite="USER-TIMING-2#dom-performancemark"><code>PerformanceMark</code></a>
 					</td>
+                                        <td><code>True</code></td>
+                                        <td><code>Infinite</code></td>
 					<td>[[!USER-TIMING-2]]</td>
 					<td>
 						<a href="https://www.w3.org/webperf/">W3C</a>
@@ -108,6 +116,8 @@
 						<a data-cite=
 						"USER-TIMING-2#dom-performancemeasure"><code>PerformanceMeasure</code></a>
 					</td>
+                                        <td><code>True</code></td>
+                                        <td><code>Infinite</code></td>
 					<td>[[!USER-TIMING-2]]</td>
 					<td>
 						<a href="https://www.w3.org/webperf/">W3C</a>
@@ -119,6 +129,8 @@
 						<a data-cite=
 						"NAVIGATION-TIMING-2#dom-performancenavigationtiming"><code>PerformanceNavigationTiming</code></a>
 					</td>
+                                        <td><code>True</code></td>
+                                        <td><code>Infinite</code></td>
 					<td>[[!NAVIGATION-TIMING-2]]</td>
 					<td>
 						<a href="https://www.w3.org/webperf/">W3C</a>
@@ -130,6 +142,8 @@
 						<a data-cite=
 						"RESOURCE-TIMING-2#dom-performanceresourcetiming"><code>PerformanceResourceTiming</code></a>
 					</td>
+                                        <td><code>True</code></td>
+                                        <td><code>250</code></td>
 					<td>[[!RESOURCE-TIMING-2]]</td>
 					<td>
 						<a href="https://www.w3.org/webperf/">W3C</a>
@@ -141,6 +155,8 @@
 						<a data-cite=
 						"LONGTASKS-1#performancelongtasktiming"><code>PerformanceLongTaskTiming</code></a>
 					</td>
+                                        <td><code>False</code></td>
+                                        <td>NA</td>
 					<td>[[!LONGTASKS-1]]</td>
 					<td>
 						<a href="https://www.w3.org/webperf/">W3C</a>
@@ -152,6 +168,8 @@
 						<a data-cite=
 						"PAINT-TIMING#performancepainttiming"><code>PerformancePaintTiming</code></a>
 					</td>
+                                        <td><code>True</code></td>
+                                        <td><code>1</code></td>
 					<td>[[!PAINT-TIMING]]</td>
 					<td>
 						<a href="https://www.w3.org/webperf/">W3C</a>

--- a/index.html
+++ b/index.html
@@ -92,8 +92,8 @@
 				<tr>
 					<th><code>entryType</code> Identifier</th>
 					<th>Interface Type(s)</th>
-                                        <th>Available From Timeline</th>
-                                        <th>Max Buffer Size</th>
+                                        <th><a>availableFromTimeline</a></th>
+                                        <th><a>maxBufferSize</a></th>
 					<th>Public Specification(s)</th>
 					<th>Requestor Contact</th>
 				</tr>

--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
                         <li>Each entry must include an <dfn><code>availableFromTimeline</code></dfn> boolean
                             indicating whether this entry type is available from the
                             <a data-cite="hr-time-2#sec-performance">Performance</a> interface. </li>
-                        <li>Each entry must include a <dfn><code>maxBufferSize</code></dfn> indicating the max
+                        <li>Each entry must include a <dfn><code>maxBufferSize</code></dfn> indicating the maximum
                             buffer size for this entry type.</li>
 		</ul>
 		<p>An update to this registry is an addition, change or deletion of an

--- a/index.html
+++ b/index.html
@@ -67,10 +67,11 @@
 			<li>Each entry should include a link that references a public available
 			specification (PAS) that defines the associated interface type.</li>
 			<li>Each entry must include contact information of the requestor.</li>
-                        <li>Each entry must include an <dfn data-cite=
-		'PERFORMANCE-TIMELINE-2#dom-performancetimeline-availableFromTimeline'><code>availableFromTimeline</code></dfn> boolean.
-                        <li>Each entry must include a <dfn data-cite=
-		'PERFORMANCE-TIMELINE-2#dom-performancetimeline-maxBufferSize'><code>maxBufferSize</code></dfn> indication.
+                        <li>Each entry must include an <dfn><code>availableFromTimeline</code></dfn> boolean
+                            indicating whether this entry type is available from the
+                            <a data-cite="hr-time-2#sec-performance">Performance</a> interface. </li>
+                        <li>Each entry must include a <dfn><code>maxBufferSize</code></dfn> indicating the max
+                            buffer size for this entry type.</li>
 		</ul>
 		<p>An update to this registry is an addition, change or deletion of an
 		identifier. Any person can request an update to this registry by pull

--- a/index.html
+++ b/index.html
@@ -156,7 +156,7 @@
 						"LONGTASKS-1#performancelongtasktiming"><code>PerformanceLongTaskTiming</code></a>
 					</td>
                                         <td><code>False</code></td>
-                                        <td>NA</td>
+                                        <td>0</td>
 					<td>[[!LONGTASKS-1]]</td>
 					<td>
 						<a href="https://www.w3.org/webperf/">W3C</a>


### PR DESCRIPTION
Add availableFromTimeline and maxBufferSize values to the registry. 

Dependent on this pull request landing: https://github.com/w3c/performance-timeline/pull/135


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ehanley324/timing-entrytypes-registry/pull/1.html" title="Last updated on Jun 25, 2019, 6:23 PM UTC (5cc6b1f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/timing-entrytypes-registry/1/3449716...ehanley324:5cc6b1f.html" title="Last updated on Jun 25, 2019, 6:23 PM UTC (5cc6b1f)">Diff</a>