### PR TITLE
Export `availableFromTimeline`

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
 			<li>Each entry should include a link that references a public available
 			specification (PAS) that defines the associated interface type.</li>
 			<li>Each entry must include contact information of the requestor.</li>
-                        <li>Each entry must include an <dfn><code>availableFromTimeline</code></dfn> boolean
+                        <li>Each entry must include an <dfn export><code>availableFromTimeline</code></dfn> boolean
                             indicating whether this entry type is available from the
                             <a data-cite="hr-time-2#sec-performance">Performance</a> interface. </li>
                         <li>Each entry must include a <dfn><code>maxBufferSize</code></dfn> indicating the maximum


### PR DESCRIPTION
This allows other specs to cross-reference it easily, e.g. Performance Timeline.