### PR TITLE
Correct maxBufferSize for PaintTiming

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,7 +170,7 @@
 						"PAINT-TIMING#performancepainttiming"><code>PerformancePaintTiming</code></a>
 					</td>
                                         <td><code>True</code></td>
-                                        <td><code>1</code></td>
+                                        <td><code>2</code></td>
 					<td>[[!PAINT-TIMING]]</td>
 					<td>
 						<a href="https://www.w3.org/webperf/">W3C</a>


### PR DESCRIPTION
There will be 2 entries (first-paint and first-contentful-paint), so the max should be 2, not 1.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/timing-entrytypes-registry/pull/3.html" title="Last updated on Jul 16, 2019, 2:15 PM UTC (c2b7ba0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/timing-entrytypes-registry/3/38df171...c2b7ba0.html" title="Last updated on Jul 16, 2019, 2:15 PM UTC (c2b7ba0)">Diff</a>