### PR TITLE
Add longtasks buffering support

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,7 +157,7 @@
 						"LONGTASKS-1#performancelongtasktiming"><code>PerformanceLongTaskTiming</code></a>
 					</td>
                                         <td><code>False</code></td>
-                                        <td>0</td>
+                                        <td>200</td>
 					<td>[[!LONGTASKS-1]]</td>
 					<td>
 						<a href="https://www.w3.org/webperf/">W3C</a>


### PR DESCRIPTION
Based on the discussion from the latest WebPerf call, we've decided to allow the buffered flag to work with longtasks. We've set a maxBufferSize of 200 tentatively. It's likely going to be enough but we can consider increasing it in the future if people are hitting the 200 limit when getting entries from the PeformanceObserver.

With this change, we only need to change the longtasks spec to remove the part saying "NOTE: the "queue a PerformanceEntry" algorithm will end up doing nothing if no observers are registered. Implementations likely will want to bail out from this algorithm earlier in that case, instead of assembling all the above information only to find out nobody is listening for it."

@rniwa FYI since you weren't at the call


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/timing-entrytypes-registry/pull/8.html" title="Last updated on Nov 21, 2019, 10:09 PM UTC (e2a3efc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/timing-entrytypes-registry/8/c48c868...e2a3efc.html" title="Last updated on Nov 21, 2019, 10:09 PM UTC (e2a3efc)">Diff</a>