### PR TITLE
Better define updates to the registry

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,8 +73,16 @@
                         <li>Each entry must include a <dfn><code>maxBufferSize</code></dfn> indicating the maximum
                             buffer size for this entry type.</li>
 		</ul>
-		<p>An update to this registry is an addition, change or deletion of an
-		identifier. Any person can request an update to this registry by pull
+		<p>An update to this registry is one of the following:
+      <ul>
+        <li>An addition or deprecation of an identifier. Removal of identifiers is
+          strongly discouraged.
+        </li>
+        <li>An addition, change, or removal of a column to the table. The column
+          containing identifiers must not be removed or changed.
+        </li>
+      </ul> 
+    Any person can request an update to this registry by pull
 		requests to the <a href=
 		"https://github.com/w3c/timing-entrytypes-registry/">timing-entrytypes-registry</a>
 		repository. The Web Performance Working Group will place it on an upcoming


### PR DESCRIPTION
I want to add a new column soon so update the definition of update accordingly. I think this also fixes https://github.com/w3c/timing-entrytypes-registry/issues/5 and https://github.com/w3c/timing-entrytypes-registry/issues/6


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/timing-entrytypes-registry/pull/11.html" title="Last updated on Apr 6, 2020, 9:34 PM UTC (c66f885)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/timing-entrytypes-registry/11/eb5d635...c66f885.html" title="Last updated on Apr 6, 2020, 9:34 PM UTC (c66f885)">Diff</a>