### PR TITLE
Expand `should add entry` to perf timeline

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,11 +73,21 @@
       <li>Each entry type must include a <dfn><code>maxBufferSize</code></dfn> indicating the maximum
         buffer size for this entry type.</li>
       <li>Each entry type must specify an algorithm <dfn>should add entry</dfn> which,
-        given a {{PerformanceEntry}} |entry| of the entry type and a <a data-cite=
+        given a {{PerformanceEntry}} |entry| of the entry type and optionally a <a data-cite=
         'PERFORMANCE-TIMELINE-2#performanceobserverinit-dictionary'>PerformanceObserverInit</a>
-        |options| of an observer observing that entry type, determines whether |entry| must
-        be appended to the observer's <a data-cite=
-        'PERFORMANCE-TIMELINE-2#dfn-observer-buffer'>observer buffer</a> or not.</li>
+        |options| of an observer observing that entry type, determines the following:
+        <ol>
+          <li>If |options| was not provided, whether |entry| is eligible to be added to the
+          performance timeline, regardless of limitations in the buffer size.
+          </li>
+          <li>Otherwise, given <a data-cite=
+          "PERFORMANCE-TIMELINE-2#dfn-registered-performance-observer">registered performance observer</a>
+          |regObs| containing |options| in its <a data-cite=PERFORMANCE-TIMELINE-2#dfn-options-list>
+          options list</a>, whether |entry| must be appended to |regObs|'s <a data-cite=
+          "PERFORMANCE-TIMELINE-2#dfn-observer">observer's</a> <a data-cite=
+          "PERFORMANCE-TIMELINE-2#dfn-observer-buffer">observer buffer</a>.</li>
+        </ol>
+      </li>
     </ul>
     <p>An update to this registry is one of the following:
       <ul>
@@ -87,7 +97,7 @@
         <li>An addition, change, or removal of a column to the table. The column
           containing identifiers must not be removed or changed.
         </li>
-      </ul> 
+      </ul>
     Any person can request an update to this registry by pull
     requests to the <a href=
     "https://github.com/w3c/timing-entrytypes-registry/">timing-entrytypes-registry</a>


### PR DESCRIPTION
The purpose of this PR is to enable expanding the method in Event Timing so that it states that only entries with `duration` greater than or equal to 104 are added to the performance timeline.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/timing-entrytypes-registry/pull/15.html" title="Last updated on Aug 14, 2020, 3:30 PM UTC (76f5a44)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/timing-entrytypes-registry/15/da83fd3...76f5a44.html" title="Last updated on Aug 14, 2020, 3:30 PM UTC (76f5a44)">Diff</a>